### PR TITLE
Add screen rotation management

### DIFF
--- a/Pod/Classes/KGDrawerViewController.swift
+++ b/Pod/Classes/KGDrawerViewController.swift
@@ -15,11 +15,11 @@ public enum KGDrawerSide: CGFloat {
 }
 
 public class KGDrawerViewController: UIViewController {
-    
+
     let defaultDuration:NSTimeInterval = 0.3
-    
+
     // MARK: Initialization
-    
+
     override public init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     }
@@ -27,12 +27,12 @@ public class KGDrawerViewController: UIViewController {
     required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override public func loadView() {
         view = drawerView
     }
-    
-    
+
+
     private var _drawerView: KGDrawerView?
     var drawerView: KGDrawerView {
         get {
@@ -45,9 +45,9 @@ public class KGDrawerViewController: UIViewController {
             return retVal
         }
     }
-    
+
     // TODO: Add ability to supply custom animator.
-    
+
     private var _animator: KGDrawerSpringAnimator?
     public var animator: KGDrawerSpringAnimator {
         get {
@@ -59,9 +59,9 @@ public class KGDrawerViewController: UIViewController {
             return retVal
         }
     }
-    
+
     // MARK: Interaction
-    
+
     public func openDrawer(side: KGDrawerSide, animated:Bool, complete: (finished: Bool) -> Void) {
         if currentlyOpenedSide != side {
             if let sideView = drawerView.viewContainerForDrawerSide(side) {
@@ -73,15 +73,15 @@ public class KGDrawerViewController: UIViewController {
                 } else {
                     self.animator.openDrawer(side, drawerView: sideView, centerView: centerView, animated: animated, complete: complete)
                 }
-                
+
                 addDrawerGestures()
                 drawerView.willOpenDrawer(self)
             }
         }
-        
+
         currentlyOpenedSide = side
     }
-    
+
     public func closeDrawer(side: KGDrawerSide, animated: Bool, complete: (finished: Bool) -> Void) {
         if (currentlyOpenedSide == side && currentlyOpenedSide != .None) {
             if let sideView = drawerView.viewContainerForDrawerSide(side) {
@@ -93,7 +93,7 @@ public class KGDrawerViewController: UIViewController {
             }
         }
     }
-    
+
     public func toggleDrawer(side: KGDrawerSide, animated: Bool, complete: (finished: Bool) -> Void) {
         if side != .None {
             if side == currentlyOpenedSide {
@@ -103,27 +103,27 @@ public class KGDrawerViewController: UIViewController {
             }
         }
     }
-    
+
     // MARK: Gestures
-    
+
     func addDrawerGestures() {
         centerViewController?.view.userInteractionEnabled = false
         drawerView.centerViewContainer.addGestureRecognizer(toggleDrawerTapGestureRecognizer)
     }
-    
+
     func restoreGestures() {
         drawerView.centerViewContainer.removeGestureRecognizer(toggleDrawerTapGestureRecognizer)
         centerViewController?.view.userInteractionEnabled = true
     }
-    
+
     func centerViewContainerTapped(sender: AnyObject) {
         closeDrawer(currentlyOpenedSide, animated: true) { (finished) -> Void in
             // Do nothing
         }
     }
-    
+
     // MARK: Helpers
-    
+
     func viewContainer(side: KGDrawerSide) -> UIViewController? {
         switch side {
         case .Left:
@@ -134,32 +134,32 @@ public class KGDrawerViewController: UIViewController {
             return nil
         }
     }
-    
+
     func replaceViewController(sourceViewController: UIViewController?, destinationViewController: UIViewController, container: UIView) {
-        
+
         sourceViewController?.willMoveToParentViewController(nil)
         sourceViewController?.view.removeFromSuperview()
         sourceViewController?.removeFromParentViewController()
-        
+
         self.addChildViewController(destinationViewController)
         container.addSubview(destinationViewController.view)
-        
+
         let destinationView = destinationViewController.view
         destinationView.translatesAutoresizingMaskIntoConstraints = false
-        
+
         container.removeConstraints(container.constraints)
-        
+
         let views: [String:UIView] = ["v1" : destinationView]
         container.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|[v1]|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views))
         container.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|[v1]|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: views))
-        
+
         destinationViewController.didMoveToParentViewController(self)
     }
-    
+
     // MARK: Private computed properties
-    
+
     public var currentlyOpenedSide: KGDrawerSide = .None
-    
+
     // MARK: Accessors
     private var _leftViewController: UIViewController?
     public var leftViewController: UIViewController? {
@@ -171,7 +171,7 @@ public class KGDrawerViewController: UIViewController {
             _leftViewController = newValue!
         }
     }
-    
+
     private var _rightViewController: UIViewController?
     public var rightViewController: UIViewController? {
         get {
@@ -182,7 +182,7 @@ public class KGDrawerViewController: UIViewController {
             _rightViewController = newValue
         }
     }
-    
+
     private var _centerViewController: UIViewController?
     public var centerViewController: UIViewController? {
         get {
@@ -193,13 +193,13 @@ public class KGDrawerViewController: UIViewController {
             _centerViewController = newValue
         }
     }
-    
+
     private lazy var toggleDrawerTapGestureRecognizer: UITapGestureRecognizer = {
         [unowned self] in
         let gesture = UITapGestureRecognizer(target: self, action: "centerViewContainerTapped:")
         return gesture
     }()
-    
+
     public var leftDrawerWidth: CGFloat {
         get  {
             return drawerView.leftViewContainerWidth
@@ -208,7 +208,7 @@ public class KGDrawerViewController: UIViewController {
             drawerView.leftViewContainerWidth = newValue
         }
     }
-    
+
     public var rightDrawerWidth: CGFloat {
         get {
             return drawerView.rightViewContainerWidth
@@ -217,19 +217,19 @@ public class KGDrawerViewController: UIViewController {
             drawerView.rightViewContainerWidth = newValue
         }
     }
-    
+
     public var leftDrawerRevealWidth: CGFloat {
         get {
             return drawerView.leftViewContainerWidth
         }
     }
-    
+
     public var rightDrawerRevealWidth: CGFloat {
         get {
             return drawerView.rightViewContainerWidth
         }
     }
-    
+
     public var backgroundImage: UIImage? {
         get {
             return drawerView.backgroundImageView.image
@@ -238,21 +238,31 @@ public class KGDrawerViewController: UIViewController {
             drawerView.backgroundImageView.image = newValue
         }
     }
-    
+
     // MARK: Status Bar
-    
+
     override public func childViewControllerForStatusBarHidden() -> UIViewController? {
         return centerViewController
     }
-    
+
     override public func childViewControllerForStatusBarStyle() -> UIViewController? {
         return centerViewController
     }
-    
+
     // MARK: Memory Management
-    
+
     override public func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
     }
-    
+
+    // MARK: Screen rotation management
+    public override func supportedInterfaceOrientations() -> UIInterfaceOrientationMask {
+        let supportedOrientations:UIInterfaceOrientationMask
+        if let centralVC = self.centerViewController {
+            supportedOrientations = centralVC.supportedInterfaceOrientations()
+        } else {
+            supportedOrientations = super.supportedInterfaceOrientations()
+        }
+        return supportedOrientations
+    }
 }


### PR DESCRIPTION
Allows the central view controller to provide an overriden
supportedInterfaceOriantions method and decide wether or not it can
rotate
