### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pod 'KGFloatingDrawer', '~> 0.2.0'
 
 ###Important Note
 
-KGFloatingDrawer requires `Swift 2.0`, `XCode 7.0` and `CocoaPods 0.36.0`
+KGFloatingDrawer requires `Swift 2.0`, `Xcode 7.0` and `CocoaPods 0.36.0`
 
 
 #How it Works


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
